### PR TITLE
Fix the ugly code highlight gray background

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,7 @@
 
     <!-- [[! highlight.js ]] -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css">
+    <style>.hljs { background: none; }</style>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
 


### PR DESCRIPTION
This will fix the ugly code highlight gray background caused by a style (`.hljs`) in highlight.js CSS file.

**Before:**
![before](https://cloud.githubusercontent.com/assets/5745261/14415515/39513354-ffca-11e5-84dc-89310533f3d4.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/5745261/14415519/4315b2ca-ffca-11e5-98e7-a9aa42d7305b.png)
