### PR TITLE
Improve page styling condition expression

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
     {% include head.html %}
 
 </head>
-<body class="{% if page.url contains 'page' %}paged archive-template{% elsif page.class %}{{ page.class }}{% else %}home-template{% endif %} nav-closed">
+<body class="{% if paginator.page > 1 %}paged archive-template{% elsif page.class %}{{ page.class }}{% else %}home-template{% endif %} nav-closed">
 
     {% include navigation.html %}
 


### PR DESCRIPTION
The condition expression for checking current page is prone to error. If user creates a post with the word `page` in its slug, Jekyll will apply a wrong styling to that post.

A better method is to check for the paginator's current page number. If it's larger than 1, then the user is on `page2` or greater. If not, then the user must be on the home page.
