### PR TITLE
Fix broken links in author pagination

### DIFF
--- a/_includes/author_pagination.html
+++ b/_includes/author_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ site.baseurl }}author/{{ site.nickname }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ site.baseurl }}author/{{ page.author }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ site.baseurl }}author/{{ site.nickname }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ site.baseurl }}author/{{ page.author }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
-    {% if paginator.next_page %} 
-        <a class="older-posts" href="{{ site.baseurl }}author/{{ site.nickname }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
-    {% endif %} 
+    {% if paginator.next_page %}
+        <a class="older-posts" href="{{ site.baseurl }}author/{{ page.author }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+    {% endif %}
 </nav>


### PR DESCRIPTION
Most links ended in a non-generic way. This should allow to work for all authors at the same time.