### PR TITLE
Fix relative assets

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,11 +18,11 @@ permalink: 404.html
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
-    <link rel="shortcut icon" href="{{ site.baseurl }}assets/images/favicon.ico">
+    <link rel="shortcut icon" href="{{ "assets/images/favicon.ico" | relative_url }}">
     <meta http-equiv="cleartype" content="on">
 
     <link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
-    <link rel="stylesheet" href="{{ site.baseurl }}assets/css/ghost.min.css" />
+    <link rel="stylesheet" href="{{ "assets/css/ghost.min.css" | relative_url }}" />
 </head>
 <body>
     <main role="main" id="main">
@@ -33,12 +33,12 @@ permalink: 404.html
                         <section class="error-details">
                             <img
                                     class="error-ghost"
-                                    src="{{ site.baseurl }}assets/images/404.png"
-                                    srcset="{{ site.baseurl }}assets/images/404.png"/>
+                                    src="{{ "assets/images/404.png" | relative_url }}"
+                                    srcset="{{ "assets/images/404.png" | relative_url }}"/>
                             <section class="error-message">
                                 <h1 class="error-code">404</h1>
                                 <h2 class="error-description">Page not found</h2>
-                                <a class="error-link" href="{{ site.baseurl }}">Go to the front page →</a>
+                                <a class="error-link" href="{{ "/" | relative_url }}">Go to the front page →</a>
                             </section>
                         </section>
                     </section>

--- a/_includes/author_pagination.html
+++ b/_includes/author_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ site.baseurl }}author/{{ page.author }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "author/" | append: page.author | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ site.baseurl }}author/{{ page.author }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "author/" | append: page.author | append: "/page" | append: paginator.previous_page | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
     {% if paginator.next_page %}
-        <a class="older-posts" href="{{ site.baseurl }}author/{{ page.author }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="{{ "author/" | append: page.author | append: "/page" | append: paginator.next_page | relative_url }}" title="Next Page">Older Posts &raquo;</a>
     {% endif %}
 </nav>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,19 +1,19 @@
-    <link rel="canonical" href="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url }}" />
+    <link rel="canonical" href="{{ page.url | absolute_url }}" />
     <meta name="referrer" content="origin" />
-    <link rel="next" href="{{ site.baseurl }}page2/" />
+    <link rel="next" href="{{ "page2" | relative_url }}" />
 
     <meta property="og:site_name" content="{{ site.name }}" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}" />
     <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
-    <meta property="og:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url }}" />
-    <meta property="og:image" content="{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}assets/images/cover1.jpg{% endif %}" />
+    <meta property="og:url" content="{{ page.url | absolute_url }}" />
+    <meta property="og:image" content="{% if page.cover %}{{ page.cover | absolute_url }}{% else %}{{ "assets/images/cover1.jpg" | absolute_url }}{% endif %}" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}" />
     <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
-    <meta name="twitter:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url }}" />
-    <meta name="twitter:image:src" content="{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}assets/images/cover1.jpg{% endif %}" />
+    <meta name="twitter:url" content="{{ page.url | absolute_url }}" />
+    <meta name="twitter:image:src" content="{% if page.cover %}{{ page.cover | absolute_url }}{% else %}{{ "assets/images/cover1.jpg" | absolute_url }}{% endif %}" />
 
     <script type="application/ld+json">
 {
@@ -21,11 +21,11 @@
     "@type": "Website",
     "publisher": "{{ site.name }}",
     "name": "{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}",
-    "url": "{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url }}",
-    "image": "{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}assets/images/cover1.jpg{% endif %}",
+    "url": "{{ page.url | absolute_url }}",
+    "image": "{% if page.cover %}{{ page.cover | absolute_url }}{% else %}{{ "assets/images/cover1.jpg" | absolute_url }}{% endif %}",
     "description": "{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}"
 }
     </script>
 
     <meta name="generator" content="Jekyll 3.0.0" />
-    <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.baseurl }}feed.xml" />
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ "feed.xml" | relative_url }}" />

--- a/_includes/loop.html
+++ b/_includes/loop.html
@@ -17,18 +17,18 @@
     {% for post in paginator.posts %}
     <article class="post">
         <header class="post-header">
-            <h2 class="post-title"><a href="{{ site.baseurl }}{{ post.url | remove: '/' }}">{{ post.title }}</a></h2>
+            <h2 class="post-title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
         </header>
         <section class="post-excerpt">
-            <p>{{ post.content | strip_html | truncatewords: 26 }} <a class="read-more" href="{{ site.baseurl }}{{ post.url | remove: '/' }}">&raquo;</a></p>
+            <p>{{ post.content | strip_html | truncatewords: 26 }} <a class="read-more" href="{{ post.url | relative_url }}">&raquo;</a></p>
         </section>
         <footer class="post-meta">
             {% for author in site.data.authors %}
                 {% if author[1].username == post.author %}
 
-                {% if author[1].assets %}<img class="author-thumb" src="{{ site.baseurl }}{{ author[1].assets }}" alt="Author image" nopin="nopin" />{% endif %}
+                {% if author[1].assets %}<img class="author-thumb" src="{{ author[1].assets | relative_url }}" alt="Author image" nopin="nopin" />{% endif %}
                 <!-- author -->
-                <a href='{{ site.baseurl }}author/{{ post.author }}'>{{ author[1].name }}</a>
+                <a href='{{ "author/" | append: post.author | relative_url }}'>{{ author[1].name }}</a>
 
                 {% endif %}
             {% endfor %}
@@ -38,9 +38,9 @@
                 on
                 {% for tag in post.tags %}
                     {% if forloop.index == post.tags.size %}
-                       <a href='{{ site.baseurl }}tag/{{ tag }}'>{{ tag | capitalize }}</a>
+                       <a href='{{ "tag/" | append: tag | relative_url }}'>{{ tag | capitalize }}</a>
                     {% else %}
-                       <a href='{{ site.baseurl }}tag/{{ tag }}'>{{ tag | capitalize }}</a>,
+                       <a href='{{ "tag/" | append: tag | relative_url }}'>{{ tag | capitalize }}</a>,
                     {% endif %}
                 {% endfor %}
             {% endif %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -4,17 +4,17 @@
         <span class="hidden">Close</span>
     </a>
     <ul>
-        <li class="nav-home {% if page.current == 'home' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}">Home</a></li>
-        <li class="nav-about {% if page.current == 'about' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}about">About</a></li>
-        <li class="nav-fables {% if page.url contains 'fables' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}tag/fables">Fables</a></li>
-        <li class="nav-speeches {% if page.url contains 'speeches' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}tag/speeches">Speeches</a></li>
-        <li class="nav-fiction {% if page.url contains 'fiction' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}tag/fiction">Fiction</a></li>
-        <li class="nav-author {% if page.url contains 'casper' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}author/casper">Casper</a></li>
-        <li class="nav-author {% if page.url contains 'edgar' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}author/edgar">Edgar</a></li>
-        <li class="nav-author {% if page.url contains 'abraham' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}author/abraham">Abraham</a></li>
-        <li class="nav-author {% if page.url contains 'martin' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}author/martin">Martin</a></li>
-        <li class="nav-author {% if page.url contains 'lewis' %} nav-current{% endif %}" role="presentation"><a href="{{ site.baseurl }}author/lewis">Lewis</a></li>
+        <li class="nav-home {% if page.current == 'home' %} nav-current{% endif %}" role="presentation"><a href="{{ "/" | relative_url }}">Home</a></li>
+        <li class="nav-about {% if page.current == 'about' %} nav-current{% endif %}" role="presentation"><a href="{{ "about" | relative_url }}">About</a></li>
+        <li class="nav-fables {% if page.url contains 'fables' %} nav-current{% endif %}" role="presentation"><a href="{{ "tag/fables" | relative_url }}">Fables</a></li>
+        <li class="nav-speeches {% if page.url contains 'speeches' %} nav-current{% endif %}" role="presentation"><a href="{{ "tag/speeches" | relative_url }}">Speeches</a></li>
+        <li class="nav-fiction {% if page.url contains 'fiction' %} nav-current{% endif %}" role="presentation"><a href="{{ "tag/fiction" | relative_url }}">Fiction</a></li>
+        <li class="nav-author {% if page.url contains 'casper' %} nav-current{% endif %}" role="presentation"><a href="{{ "author/casper" | relative_url }}">Casper</a></li>
+        <li class="nav-author {% if page.url contains 'edgar' %} nav-current{% endif %}" role="presentation"><a href="{{ "author/edgar" | relative_url }}">Edgar</a></li>
+        <li class="nav-author {% if page.url contains 'abraham' %} nav-current{% endif %}" role="presentation"><a href="{{ "author/abraham" | relative_url }}">Abraham</a></li>
+        <li class="nav-author {% if page.url contains 'martin' %} nav-current{% endif %}" role="presentation"><a href="{{ "author/martin" | relative_url }}">Martin</a></li>
+        <li class="nav-author {% if page.url contains 'lewis' %} nav-current{% endif %}" role="presentation"><a href="{{ "author/lewis" | relative_url }}">Lewis</a></li>
     </ul>
-    <a class="subscribe-button icon-feed" href="{{ site.baseurl }}feed.xml">Subscribe</a>
+    <a class="subscribe-button icon-feed" href="{{ "feed.xml" | relative_url }}">Subscribe</a>
 </div>
 <span class="nav-cover"></span>

--- a/_includes/post_pagination.html
+++ b/_includes/post_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ site.baseurl }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "/" | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ site.baseurl }}page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "page" | append: paginator.previous_page | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
     {% if paginator.next_page %} 
-        <a class="older-posts" href="{{ site.baseurl }}page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="{{ "page" | append: paginator.next_page | relative_url }}" title="Next Page">Older Posts &raquo;</a>
     {% endif %} 
 </nav>

--- a/_includes/tag_pagination.html
+++ b/_includes/tag_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ site.baseurl }}tag/{{ page.tag }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "tag/" | append: page.tag | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ site.baseurl }}tag/{{ page.tag }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "tag/" | append: page.tag | append: "/page" | append: paginator.previous_page | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
     {% if paginator.next_page %} 
-        <a class="older-posts" href="{{ site.baseurl }}tag/{{ page.tag }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="{{ "tag/" | append: page.tag | append: "/page" | append: paginator.next_page | relative_url }}" title="Next Page">Older Posts &raquo;</a>
     {% endif %} 
 </nav>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -15,9 +15,9 @@ current: author
 
 <!-- Everything inside the #author tags pulls data from the author -->
 <!-- #author  -->
-    <header class="main-header author-head {% if page.cover %}" style="background-image: url({{ site.baseurl }}{{ page.cover }}) {% else %}no-cover{% endif %}">
+    <header class="main-header author-head {% if page.cover %}" style="background-image: url({{ page.cover | relative_url }}) {% else %}no-cover{% endif %}">
         <nav class="main-nav overlay clearfix">
-            {% if page.logo %}<a class="blog-logo" href="{{ site.baseurl }}"><img src="{{ site.baseurl }}{{ page.logo }}" alt="Blog Logo" /></a>{% endif %}
+            {% if page.logo %}<a class="blog-logo" href="{{ "/" | relative_url }}"><img src="{{ page.logo | relative_url }}" alt="Blog Logo" /></a>{% endif %}
             {% if page.navigation %}
                 <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
             {% endif %}
@@ -29,7 +29,7 @@ current: author
             {% if author[1].username == page.author %}
                 {% if author[1].assets %}
                 <figure class="author-image">
-                    <div class="img" style="background-image: url({{ site.baseurl }}{{ author[1].assets }})"><span class="hidden">{{ author[1].name }}'s Picture</span></div>
+                    <div class="img" style="background-image: url({{ author[1].assets | relative_url }})"><span class="hidden">{{ author[1].name }}'s Picture</span></div>
                 </figure>
                 {% endif %}
                 <h1 class="author-title">{{ author[1].name }}</h1>

--- a/_layouts/author.xml
+++ b/_layouts/author.xml
@@ -5,10 +5,10 @@ title: nil
 {% for post in page.posts %}
 	<item>
 	  <title>{{ post.title }}</title>
-	  <link>{{ site.baseurl }}{{ post.url }}</link>
+	  <link>{{ post.url | relative_url }}</link>
 	  <author>{{ site.author }}</author>
 	  <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
-	  <guid>{{ site.baseurl }}{{ post.url }}</guid>
+	  <guid>{{ post.url | relative_url }}</guid>
 	  <description><![CDATA[
 	     {{ post.content | expand_urls : site.url }}
 	  ]]></description>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,12 +14,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Brand icon -->
-    <link rel="shortcut icon" href="{{ site.baseurl }}assets/images/favicon.ico" >
+    <link rel="shortcut icon" href="{{ "assets/images/favicon.ico" | relative_url }}" >
 
     <!-- Styles'n'Scripts -->
-    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}assets/css/screen.css" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/css/screen.css" | relative_url }}" />
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400" />
-    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}assets/css/syntax.css" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/css/syntax.css" | relative_url }}" />
 
     <!-- highlight.js -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css">
@@ -41,7 +41,7 @@
 
         <!-- The tiny footer at the very bottom -->
         <footer class="site-footer clearfix">
-          <section class="copyright"><a href="{{ site.baseurl }}">{{ site.name }}</a> &copy; {{  site.time | date: '%Y' }}</section>
+          <section class="copyright"><a href="{{ "/" | relative_url }}">{{ site.name }}</a> &copy; {{  site.time | date: '%Y' }}</section>
           <section class="poweredby">Proudly published with <a href="https://jekyllrb.com/">Jekyll</a> using <a href="https://github.com/jekyllt/jasper">Jasper</a></section>
         </footer>
     </div>
@@ -56,9 +56,9 @@
     <!-- Add Google Analytics  -->
     {% include analytics.html %}
     <!-- Fitvids makes video embeds responsive and awesome -->
-    <script type="text/javascript" src="{{ site.baseurl }}assets/js/jquery.fitvids.js"></script>
+    <script type="text/javascript" src="{{ "assets/js/jquery.fitvids.js" | relative_url }}"></script>
     <!-- The main JavaScript file for Casper -->
-    <script type="text/javascript" src="{{ site.baseurl }}assets/js/index.js"></script>
+    <script type="text/javascript" src="{{ "assets/js/index.js" | relative_url }}"></script>
 
 </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,9 +10,9 @@ class: 'page-template'
 <!-- Everything inside the #post tags pulls data from the page -->
 <!-- #post -->
 
-<header class="main-header post-head {% if page.cover %}" style="background-image: url({{ site.baseurl }}{{ page.cover }}){% else %}no-cover{% endif %}">
+<header class="main-header post-head {% if page.cover %}" style="background-image: url({{ page.cover | relative_url }}){% else %}no-cover{% endif %}">
     <nav class="main-nav {% if page.cover %}overlay{% endif %} clearfix">
-        {% if page.logo %}<a class="blog-logo" href="{{ site.baseurl }}"><img src="{{ site.baseurl }}{{ page.logo }}" alt="Blog Logo" /></a>{% endif %}
+        {% if page.logo %}<a class="blog-logo" href="{{ "/" | relative_url }}"><img src="{{ page.logo | relative_url }}" alt="Blog Logo" /></a>{% endif %}
         {% if page.navigation %}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,9 +11,9 @@ class: 'post-template'
 <!-- Everything inside the #post tags pulls data from the post -->
 <!-- #post -->
 
-<header class="main-header post-head {% if page.cover %}" style="background-image: url({{ site.baseurl }}{{ page.cover }}) {% else %}no-cover{% endif %}">
+<header class="main-header post-head {% if page.cover %}" style="background-image: url({{ page.cover | relative_url }}) {% else %}no-cover{% endif %}">
     <nav class="main-nav {% if page.cover %} overlay {% endif %} clearfix">
-        {% if page.logo %}<a class="blog-logo" href="{{ site.baseurl }}"><img src="{{ site.baseurl }}{{ page.logo }}" alt="Blog Logo" /></a>{% endif %}
+        {% if page.logo %}<a class="blog-logo" href="{{ "/" | relative_url }}"><img src="{{ page.logo | relative_url }}" alt="Blog Logo" /></a>{% endif %}
         {% if page.navigation %}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {% endif %}
@@ -27,11 +27,11 @@ class: 'post-template'
         <header class="post-header">
             <h1 class="post-title">{{ page.title }}</h1>
             <section class="post-meta">
-            <!-- <a href='{{ site.baseurl }}{{ page.about }}'>{{ site.author }}</a> -->
+            <!-- <a href='{{ page.about | relative_url }}'>{{ site.author }}</a> -->
 
             {% for author in site.data.authors %}
                 {% if author[1].username == page.author %}
-                    <a href='{{ site.baseurl }}author/{{ page.author }}'>{{ author[1].name }}</a>
+                    <a href='{{ "author/" | append: page.author | relative_url }}'>{{ author[1].name }}</a>
                 {% endif %}
             {% endfor %}
             <time class="post-date" datetime="{{ page.date | date:'%Y-%m-%d' }}">{{ page.date | date_to_string }}</time>
@@ -40,9 +40,9 @@ class: 'post-template'
                 on
                 {% for tag in page.tags %}
                     {% if forloop.index == page.tags.size %}
-                       <a href='{{ site.baseurl }}tag/{{ tag }}'>{{ tag | capitalize }}</a>
+                       <a href='{{ "tag/" | append: tag | relative_url }}'>{{ tag | capitalize }}</a>
                     {% else %}
-                       <a href='{{ site.baseurl }}tag/{{ tag }}'>{{ tag | capitalize }}</a>,
+                       <a href='{{ "tag/" | append: tag | relative_url }}'>{{ tag | capitalize }}</a>,
                     {% endif %}
                 {% endfor %}
                 {% endif %}
@@ -63,17 +63,17 @@ class: 'post-template'
                 {% if author[1].username == page.author %}
                     {% if author[1].assets %}
                         <figure class="author-image">
-                            <a class="img" href="{{ site.baseurl }}author/{{ page.author }}" style="background-image: url({{ site.baseurl }}{{ author[1].assets }})"><span class="hidden">{{ page.author }}'s Picture</span></a>
+                            <a class="img" href="{{ "author/" | append: page.author | relative_url }}" style="background-image: url({{ author[1].assets | relative_url }})"><span class="hidden">{{ page.author }}'s Picture</span></a>
                         </figure>
                     {% endif %}
 
                     <section class="author">
-                        <h4><a href="{{ site.baseurl }}author/{{ page.author }}">{{ author[1].name }}</a></h4>
+                        <h4><a href="{{ "author/" | append: page.author | relative_url }}">{{ author[1].name }}</a></h4>
 
                         {% if author[1].bio %}
                             <p> {{ author[1].bio }}</p>
                         {% else %}
-                            <p>Read <a href="{{ site.baseurl }}author/{{ page.author }}">more posts</a> by this author.</p>
+                            <p>Read <a href="{{ "author/" | append: page.author | relative_url }}">more posts</a> by this author.</p>
                         {% endif %}
                         <div class="author-meta">
                             {% if author[1].location %}<span class="author-location icon-location"> {{ author[1].location }}</span>{% endif %}
@@ -116,7 +116,7 @@ class: 'post-template'
 
     <!-- [[! next_post ]] -->{{ post.url | remove: '/' }}
     {% if page.next %}
-        <a class="read-next-story {% if page.next.cover %}" style="background-image: url({{ site.baseurl }}{{ page.next.cover }}){% else %}no-cover{% endif %}" href="{{ site.baseurl }}{{ page.next.url | remove: '/' }}">
+        <a class="read-next-story {% if page.next.cover %}" style="background-image: url({{ next.cover | relative_url }}){% else %}no-cover{% endif %}" href="{{ page.next.url | relative_url }}">
             <section class="post">
                 <h2>{{ page.next.title }}</h2>
                 <p>{{ page.next.content | strip_html | truncatewords:15 }}</p>
@@ -126,7 +126,7 @@ class: 'post-template'
     <!-- [[! /next_post ]] -->
     <!-- [[! prev_post ]] -->
     {% if page.previous %}
-        <a class="read-next-story prev {% if page.previous.cover %}" style="background-image: url({{ site.baseurl }}{{ page.previous.cover }}){% else %}no-cover{% endif %}" href="{{ site.baseurl }}{{ page.previous.url | remove: '/' }}">
+        <a class="read-next-story prev {% if page.previous.cover %}" style="background-image: url({{ previous.cover | relative_url }}){% else %}no-cover{% endif %}" href="{{ page.previous.url | relative_url }}">
             <section class="post">
                 <h2>{{ page.previous.title }}</h2>
                 <p>{{ page.previous.content | strip_html | truncatewords:15 }}</p>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -21,9 +21,9 @@ current: tag
 <!-- The tag above means - insert everything in this file into the [body] of the default.hbs template -->
 
 <!-- If we have a tag cover, display that - else blog cover - else nothing -->
-<header class="main-header tag-head {% if page.cover %}" style="background-image: url({{ site.baseurl }}{% if new_cover %}{{ new_cover }}{% else %}{{ page.cover }}{% endif%}) {% else %}no-cover{% endif %}">
+<header class="main-header tag-head {% if page.cover %}" style="background-image: url({% if new_cover %}{{ new_cover | relative_url }}{% else %}{{ page.cover | relative_url }}{% endif%}) {% else %}no-cover{% endif %}">
     <nav class="main-nav overlay clearfix">
-        {% if page.logo %}<a class="blog-logo" href="{{ site.baseurl }}"><img src="{{ site.baseurl }}{{ page.logo }}" alt="Blog Logo" /></a>{% endif %}
+        {% if page.logo %}<a class="blog-logo" href="{{ "/" | relative_url }}"><img src="{{ page.logo | relative_url }}" alt="Blog Logo" /></a>{% endif %}
         {% if page.navigation %}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {% endif %}

--- a/_layouts/tag.xml
+++ b/_layouts/tag.xml
@@ -5,10 +5,10 @@ title: nil
 {% for post in page.posts %}
 	<item>
 	  <title>{{ post.title }}</title>
-	  <link>{{ site.baseurl }}{{ post.url }}</link>
+	  <link>{{ post.url | relative_url }}</link>
 	  <author>{{ site.author }}</author>
 	  <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
-	  <guid>{{ site.baseurl }}{{ post.url }}</guid>
+	  <guid>{{ post.url | relative_url }}</guid>
 	  <description><![CDATA[
 	     {{ post.content | expand_urls : site.url }}
 	  ]]></description>

--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@ current: home
 
 <!-- The big featured header  -->
 <header class="main-header {% if page.cover %}"
-        style="background-image: url({{ site.baseurl }}{{ page.cover }}) {% else %}no-cover{% endif %}">
+        style="background-image: url({{ page.cover | relative_url }}) {% else %}no-cover{% endif %}">
     <nav class="main-nav overlay clearfix">
-        {% if page.logo %}<a class="blog-logo" href="{{ site.baseurl }}"><img src="{{ site.baseurl }}{{ page.logo }}" alt="Blog Logo" /></a>{% endif %}
+        {% if page.logo %}<a class="blog-logo" href="{{ "/" | relative_url }}"><img src="{{ page.logo | relative_url }}" alt="Blog Logo" /></a>{% endif %}
         {% if page.navigation %}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {% endif %}


### PR DESCRIPTION
Use the relative_url filter to properly format URLs instead of manually doing it.

The previous method didn't work well with Github Pages in custom domains, since posts in a subdirectory (ie,
`https://example.com/dir/post.html`) linked their assets without the leading slash, trying to load
`https://example.com/dir/assets/css/screen.css` instead.